### PR TITLE
fix(lib/table-utils) - Use TripId + VehicleId for trips query

### DIFF
--- a/lib/table-utils.js
+++ b/lib/table-utils.js
@@ -21,7 +21,7 @@ module.exports.getTripsForTripId = function (id) {
 
     result.entries.forEach(function (entity) {
       var tripQuery = new azureStorage.TableQuery()
-        .where('PartitionKey eq ?', entity.PartitionKey._)
+        .where('PartitionKey eq ?', entity.PartitionKey._ + '.' + entity.RowKey._)
         .and('RowKey gt ?', entity.StartTime._)
         .and('RowKey lt ?', entity.EndTime._);
         
@@ -90,7 +90,7 @@ module.exports.getTripsForVehicle = function (id) {
     result.entries.forEach(function (entity) {
 
       var tripQuery = new azureStorage.TableQuery()
-        .where('PartitionKey eq ?', id)
+        .where('PartitionKey eq ?', id + '.' + entity.RowKey._)
         .and('RowKey gt ?', entity.StartTime._)
         .and('RowKey lt ?', entity.EndTime._);
 

--- a/routes/vehicles.js
+++ b/routes/vehicles.js
@@ -13,7 +13,7 @@ router.get('/:id', function (req, res) {
     if(!req.params.id) {
         return res.send(400);
     }
-    
+    var targetVehicle;
     nitrogenUtils.getAllDevices()
     .then(function(vehicles) {
       
@@ -21,6 +21,7 @@ router.get('/:id', function (req, res) {
       vehicles.forEach(function(vehicle) {
         if (vehicle.id === req.params.id) {
            found = true;
+           targetVehicle = vehicle;
         }
       });
       
@@ -51,7 +52,7 @@ router.get('/:id', function (req, res) {
         {
           data: [{
             'type': 'vehicle',
-            'name': req.params.id,
+            'name': targetVehicle.name,
             'id': req.params.id,
             // we dont have any actual data for make/model/year/mileage
             'make': 'Toyota',
@@ -88,7 +89,7 @@ router.get('/', function (req, res) {
       vehicles.forEach(function(vehicle) {
         response.push({
             'type': 'vehicle',
-            'name': vehicle.id,
+            'name': vehicle.name,
             'id': vehicle.id,
             // we dont have any actual data for make/model/year/mileage
             'make': 'Toyota',


### PR DESCRIPTION
The table data model change slightly to the device id + trip start time for
the parittion key of a tripLocation entry.
